### PR TITLE
Add proxy pass directives to ssl config

### DIFF
--- a/roles/jbcs/README.md
+++ b/roles/jbcs/README.md
@@ -36,6 +36,7 @@ Role Defaults
 |`jbcs_external_domain_name`| Name for virtualhost ServerName directive | `{{ ansible_nodename }}` |
 |`jbcs_configure_firewalld`| Whether to configure firewalld ports for jbcs | `True` |
 |`jbcs_port_check`| Whether to check open ports at end of playbook | `False` |
+|`jbcs_proxy_pass`| List of proxy pass directives/options. Element keys: path, url, reverse_path, reverse_url | `[]` |
 
 
 Role Variables

--- a/roles/jbcs/meta/argument_specs.yml
+++ b/roles/jbcs/meta/argument_specs.yml
@@ -103,6 +103,10 @@ argument_specs:
                 default: False
                 description: "Whether to check open ports at end of playbook"
                 type: "bool"
+            jbcs_proxy_pass:
+                default: []
+                description: "List of proxy pass directives/options. Element keys: path, url, reverse_path, reverse_url"
+                type: "list"
     downstream:
         options:
             jbcs_offline_install:

--- a/roles/jbcs/templates/ssl.conf.j2
+++ b/roles/jbcs/templates/ssl.conf.j2
@@ -56,4 +56,16 @@ CustomLog logs/ssl_request_log "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
 </Location>
 {% endif %}
 
+{% if jbcs_proxy_pass | default([]) | length > 0 %}
+{% for proxy in jbcs_proxy_pass %}
+        HostnameLookups Off
+        UseCanonicalName Off
+        ProxyPreserveHost On
+        RequestHeader set X-Forwarded-Proto "https"
+        RequestHeader set X-Forwarded-Port "443"
+        ProxyPass {{ proxy.path }} {{ proxy.url }}
+        ProxyPassReverse {{ proxy.reverse_path }} {{ proxy.reverse_url }}
+{% endfor %}
+{% endif %}
+
 </VirtualHost>


### PR DESCRIPTION
New parameter:

| Variable | Description | Default |
|:---------|:------------|:--------|
|`jbcs_proxy_pass`| List of proxy pass directives/options. Element keys: path, url, reverse_path, reverse_url | `[]` |

allows to add ProxyPass sections to ssl.conf; example:

```yaml
    jbcs_bind_address: '*'
    jbcs_proxy_pass:
      - path: /
        url: http://instance:8080/
        reverse_path: /
        reverse_url: http://instance:8080/
```

generates:

```
        ProxyPreserveHost On
        RequestHeader set X-Forwarded-Proto "https"
        RequestHeader set X-Forwarded-Port "443"
        ProxyPass / http://instance:8080/
        ProxyPassReverse / http://instance:8080/
```