### PR TITLE
Update default jbcs version to 2.4.57

### DIFF
--- a/roles/jbcs/README.md
+++ b/roles/jbcs/README.md
@@ -19,7 +19,7 @@ Role Defaults
 |:---------|:------------|:--------|
 |`jbcs_ssl_enable`| Enable SSL | `True` |
 |`jbcs_ssl_port`| SSL listen port | `443` |
-|`jbcs_bundle`| Filename of JBCS install archive | `jbcs-httpd24-httpd-2.4.37-SP11-RHEL8-x86_64.zip` |
+|`jbcs_bundle`| Filename of JBCS install archive | `jbcs-httpd24-httpd-2.4.57-RHEL8-x86_64.zip` |
 |`jbcs_zip_path`| Destination for install archive download | `/opt/apps` |
 |`jbcs_offline_install`| Whether to use local archive or download one | `True` |
 |`jbcs_home`| Home directory | `/opt/jbcs/jbcs-httpd24-2.4/` |

--- a/roles/jbcs/defaults/main.yml
+++ b/roles/jbcs/defaults/main.yml
@@ -2,7 +2,7 @@
 jbcs_ssl_enable: true
 jbcs_ssl_port: 443
 
-jbcs_version: '2.4.37-SP11'
+jbcs_version: '2.4.57'
 jbcs_bundle: "jbcs-httpd24-httpd-{{ jbcs_version }}-RHEL8-x86_64.zip"
 jbcs_zip_path: /opt/apps/
 


### PR DESCRIPTION
Additionally, the JBCS zips follow the same logic as JWS ones so there should be support for patching (there is SP1 available, but it does not contain the base so we can't use it as a value for `jbcs_bundle`). Do you want me to create an issue for it? I will think about the implementation in the meantime.