### PR TITLE
Drop jbcs_ prefix from role's variable names

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,9 +2,9 @@
 - name: Converge
   hosts: all
   vars:
-    jbcs_configure_firewalld: False
-    jbcs_offline_install: False
-    jbcs_bind_address: '*'
+    configure_firewalld: False
+    offline_install: False
+    bind_address: '*'
     omit_rhn_output: False
     rhn_username: "{{ lookup('env', 'PROD_JBOSSNETWORK_API_CLIENTID') }}"
     rhn_password: "{{ lookup('env', 'PROD_JBOSSNETWORK_API_SECRET') }}"

--- a/roles/jbcs/README.md
+++ b/roles/jbcs/README.md
@@ -17,27 +17,27 @@ Role Defaults
 
 | Variable | Description | Default |
 |:---------|:------------|:--------|
-|`jbcs_ssl_enable`| Enable SSL | `True` |
-|`jbcs_ssl_port`| SSL listen port | `443` |
-|`jbcs_bundle`| Filename of JBCS install archive | `jbcs-httpd24-httpd-2.4.57-RHEL8-x86_64.zip` |
-|`jbcs_zip_path`| Destination for install archive download | `/opt/apps` |
-|`jbcs_offline_install`| Whether to use local archive or download one | `True` |
-|`jbcs_home`| Home directory | `/opt/jbcs/jbcs-httpd24-2.4/` |
-|`jbcs_bind_address`| Bind address | `localhost` |
-|`jbcs_listen_port`| HTTP listen port | `80` |
-|`jbcs_mod_cluster_enable`| Enable modcluster module | `True` |
-|`jbcs_mod_cluster_port`| Modcluster advertise port | `6666` |
-|`jbcs_mod_cluster_require`| Require argument for modcluster location | `all granted` |
-|`jbcs_mod_cluster_balancer`| Balancer name for modcluster cluster | `loadbalancer` |
-|`jbcs_user`| POSIX user for service | `apache` |
-|`jbcs_user_id`| POSIX uid for service | `48` |
-|`jbcs_group`| POSIX group for service | `apache` |
-|`jbcs_group_id`| POSIX gid for service | `48` |
-|`jbcs_service_name`| Name of systemd service | `jbcs` |
-|`jbcs_external_domain_name`| Name for virtualhost ServerName directive | `{{ ansible_nodename }}` |
-|`jbcs_configure_firewalld`| Whether to configure firewalld ports for jbcs | `True` |
-|`jbcs_port_check`| Whether to check open ports at end of playbook | `False` |
-|`jbcs_proxy_pass`| List of proxy pass directives/options. Element keys: path, url, reverse_path, reverse_url | `[]` |
+|`ssl_enable`| Enable SSL | `True` |
+|`ssl_port`| SSL listen port | `443` |
+|`bundle`| Filename of JBCS install archive | `jbcs-httpd24-httpd-2.4.57-RHEL8-x86_64.zip` |
+|`zip_path`| Destination for install archive download | `/opt/apps` |
+|`offline_install`| Whether to use local archive or download one | `True` |
+|`home`| Home directory | `/opt/jbcs/jbcs-httpd24-2.4/` |
+|`bind_address`| Bind address | `localhost` |
+|`listen_port`| HTTP listen port | `80` |
+|`mod_cluster_enable`| Enable modcluster module | `True` |
+|`mod_cluster_port`| Modcluster advertise port | `6666` |
+|`mod_cluster_require`| Require argument for modcluster location | `all granted` |
+|`mod_cluster_balancer`| Balancer name for modcluster cluster | `loadbalancer` |
+|`user`| POSIX user for service | `apache` |
+|`user_id`| POSIX uid for service | `48` |
+|`group`| POSIX group for service | `apache` |
+|`group_id`| POSIX gid for service | `48` |
+|`service_name`| Name of systemd service | `jbcs` |
+|`external_domain_name`| Name for virtualhost ServerName directive | `{{ ansible_nodename }}` |
+|`configure_firewalld`| Whether to configure firewalld ports for jbcs | `True` |
+|`port_check`| Whether to check open ports at end of playbook | `False` |
+|`proxy_pass`| List of proxy pass directives/options. Element keys: path, url, reverse_path, reverse_url | `[]` |
 
 
 Role Variables

--- a/roles/jbcs/defaults/main.yml
+++ b/roles/jbcs/defaults/main.yml
@@ -1,36 +1,36 @@
 ---
-jbcs_ssl_enable: true
-jbcs_ssl_port: 443
+ssl_enable: true
+ssl_port: 443
 
-jbcs_version: '2.4.57'
-jbcs_distro: RHEL8
-jbcs_arch: x86_64
+version: '2.4.57'
+distro: RHEL8
+arch: x86_64
 
-jbcs_bundle: "jbcs-httpd24-httpd-{{ jbcs_version }}-{{ jbcs_distro }}-{{ jbcs_arch }}.zip"
-jbcs_zip_path: /opt/apps/
+bundle: "jbcs-httpd24-httpd-{{ version }}-{{ distro }}-{{ arch }}.zip"
+zip_path: /opt/apps/
 
-jbcs_home: /opt/jbcs/jbcs-httpd24-2.4/
+home: /opt/jbcs/jbcs-httpd24-2.4/
 
-jbcs_bind_address: "localhost"
-jbcs_listen_port: 80
+bind_address: "localhost"
+listen_port: 80
 
-jbcs_mod_cluster_enable: true
-jbcs_mod_cluster_port: 6666
-jbcs_mod_cluster_require: "all granted"
-jbcs_mod_cluster_balancer: loadbalancer
+mod_cluster_enable: true
+mod_cluster_port: 6666
+mod_cluster_require: "all granted"
+mod_cluster_balancer: loadbalancer
 
-jbcs_user: apache
-jbcs_user_id: 48
-jbcs_group: apache
-jbcs_group_id: 48
+user: apache
+user_id: 48
+group: apache
+group_id: 48
 
-jbcs_service_name: jbcs
+service_name: jbcs
 
-jbcs_external_domain_name: "{{ ansible_nodename }}"
+external_domain_name: "{{ ansible_nodename }}"
 
-jbcs_offline_install: true
+offline_install: true
 
-jbcs_configure_firewalld: true
-jbcs_port_check: false
+configure_firewalld: true
+port_check: false
 
-jbcs_proxy_pass: []
+proxy_pass: []

--- a/roles/jbcs/handlers/main.yml
+++ b/roles/jbcs/handlers/main.yml
@@ -2,7 +2,7 @@
 - name: "Restart JBCS"
   become: true
   ansible.builtin.service:
-    name: "{{ jbcs_service_name }}.service"
+    name: "{{ service_name }}.service"
     state: restarted
 
 - name: "Expire mod_cluster cache and restart"

--- a/roles/jbcs/meta/argument_specs.yml
+++ b/roles/jbcs/meta/argument_specs.yml
@@ -1,127 +1,126 @@
 argument_specs:
     main:
         options:
-            jbcs_offline_install:
+            offline_install:
                 # line 2 of jbcs/defaults/main.yml
                 default: true
                 description: "Whether to install zipfiles from controller directory"
                 type: "bool"
-            jbcs_ssl_enable:
+            ssl_enable:
                 # line 2 of jbcs/defaults/main.yml
                 default: true
                 description: "Enable SSL"
                 type: "bool"
-            jbcs_ssl_port:
+            ssl_port:
                 # line 3 of jbcs/defaults/main.yml
                 default: 443
                 description: "SSL listen port"
                 type: "int"
-            jbcs_version:
+            version:
                 default: "2.4.57"
                 description: "Version of JBCS install archive"
                 type: "str"
-            jbcs_distro:
+            distro:
                 default: "RHEL8"
                 description: "Install on this version of RHEL"
                 type: "str"
-            jbcs_arch:
+            arch:
                 default: 'x86_64'
                 description: "Install on this architecture"
                 type: "str"
-            jbcs_bundle:
+            bundle:
                 # line 5 of jbcs/defaults/main.yml
-                default: "jbcs-httpd24-httpd-{{ jbcs_version }}-{{ jbcs_distro }}-{{ jbcs_arch }}.zip"
+                default: "jbcs-httpd24-httpd-{{ version }}-{{ distro }}-{{ arch }}.zip"
                 description: "Filename of JBCS install archive"
                 type: "str"
-            jbcs_patch_bundle:
-                default: "jbcs-httpd24-httpd-{{ jbcs_version }}-SP[0-9]*-{{ jbcs_distro }}-{{ jbcs_arch }}.zip"
+            patch_bundle:
+                default: "jbcs-httpd24-httpd-{{ version }}-SP[0-9]*-{{ distro }}-{{ arch }}.zip"
                 description: "Filename of JBCS patch install archive"
                 type: "str"
-            jbcs_zip_path:
+            zip_path:
                 # line 6 of jbcs/defaults/main.yml
                 default: "/opt/apps"
                 description: "Destination for install archive download"
                 type: "str"
-            jbcs_home:
+            home:
                 # line 8 of jbcs/defaults/main.yml
                 default: "/opt/jbcs/jbcs-httpd24-2.4/"
                 description: "Home directory"
                 type: "str"
-            jbcs_bind_address:
+            bind_address:
                 # line 10 of jbcs/defaults/main.yml
                 default: "localhost"
                 description: "Bind address"
                 type: "str"
-            jbcs_listen_port:
+            listen_port:
                 # line 11 of jbcs/defaults/main.yml
                 default: 80
                 description: "HTTP listen port"
                 type: "int"
-            jbcs_mod_cluster_enable:
+            mod_cluster_enable:
                 # line 13 of jbcs/defaults/main.yml
                 default: true
                 description: "Enable modcluster module"
                 type: "bool"
-            jbcs_mod_cluster_port:
+            mod_cluster_port:
                 # line 14 of jbcs/defaults/main.yml
                 default: 6666
                 description: "Modcluster advertise port"
                 type: "int"
-            jbcs_mod_cluster_require:
+            mod_cluster_require:
                 # line 15 of jbcs/defaults/main.yml
                 default: "all granted"
                 description: "Require argument for modcluster location"
                 type: "str"
-            jbcs_mod_cluster_balancer:
+            mod_cluster_balancer:
                 # line 16 of jbcs/defaults/main.yml
                 default: "loadbalancer"
                 description: "Balancer name for modcluster cluster"
                 type: "str"
-            jbcs_user:
+            user:
                 # line 18 of jbcs/defaults/main.yml
                 default: "apache"
                 description: "POSIX user for service"
                 type: "str"
-            jbcs_user_id:
+            user_id:
                 # line 19 of jbcs/defaults/main.yml
                 default: 48
                 description: "POSIX uid for service"
                 type: "int"
-            jbcs_group:
+            group:
                 # line 20 of jbcs/defaults/main.yml
                 default: "apache"
                 description: "POSIX group for service"
                 type: "str"
-            jbcs_group_id:
+            group_id:
                 # line 21 of jbcs/defaults/main.yml
                 default: 48
                 description: "POSIX gid for service"
                 type: "int"
-            jbcs_service_name:
+            service_name:
                 # line 23 of jbcs/defaults/main.yml
                 default: "jbcs"
                 description: "Name of systemd service"
                 type: "str"
-            jbcs_external_domain_name:
+            external_domain_name:
                 # line 25 of jbcs/defaults/main.yml
                 default: "{{ ansible_nodename }}"
                 description: "Name for virtualhost ServerName directive"
                 type: "str"
-            jbcs_configure_firewalld:
+            configure_firewalld:
                 default: true
                 description: "Whether to configure firewalld ports for jbcs"
                 type: "bool"
-            jbcs_port_check:
-                default: false
+            port_check:
                 description: "Whether to check open ports at end of playbook"
                 type: "bool"
-            jbcs_proxy_pass:
+            proxy_pass:
                 default: []
                 description: "List of proxy pass directives/options. Element keys: path, url, reverse_path, reverse_url"
                 type: "list"
     downstream:
         options:
-            jbcs_offline_install:
+            offline_install:
                 # line 2 of jbcs/defaults/main.yml
                 default: false
                 description: "Whether to install zipfiles from controller directory"

--- a/roles/jbcs/tasks/firewalld.yml
+++ b/roles/jbcs/tasks/firewalld.yml
@@ -20,8 +20,8 @@
     state: enabled
     immediate: true
   loop:
-    - "{{ jbcs_listen_port }}/tcp"
-    - "{{ jbcs_ssl_port }}/tcp"
-    - "{{ jbcs_mod_cluster_port }}/tcp"
+    - "{{ listen_port }}/tcp"
+    - "{{ ssl_port }}/tcp"
+    - "{{ mod_cluster_port }}/tcp"
   loop_control:
     loop_var: port

--- a/roles/jbcs/tasks/install.yml
+++ b/roles/jbcs/tasks/install.yml
@@ -38,7 +38,7 @@
 - name: Create directory for zipfile
   become: true
   ansible.builtin.file:
-    path: "{{ jbcs_zip_path }}"
+    path: "{{ zip_path }}"
     owner: "{{ httpd.user.name }}"
     group: "{{ httpd.group.name }}"
     mode: 0750
@@ -47,7 +47,7 @@
 ## check remote archive
 - name: Set download archive path
   ansible.builtin.set_fact:
-    archive: "{{ jbcs_zip_path }}/{{ jbcs_bundle }}"
+    archive: "{{ zip_path }}/{{ bundle }}"
 
 - name: Check download archive path
   become: true
@@ -64,7 +64,7 @@
 
 - name: Check downloaded archive
   ansible.builtin.stat:
-    path: "{{ local_path.stat.path }}/{{ jbcs_bundle }}"
+    path: "{{ local_path.stat.path }}/{{ bundle }}"
   register: local_archive_path
   delegate_to: localhost
 
@@ -72,13 +72,13 @@
   delegate_to: localhost
   run_once: true
   when:
-    - not jbcs_installed is defined
+    - not installed is defined
     - archive_path is defined
     - archive_path.stat is defined
     - not archive_path.stat.exists
     - local_archive_path.stat is defined
     - not local_archive_path.stat.exists
-    - not jbcs_offline_install
+    - not offline_install
     - rhn_username is defined and rhn_password is defined
   block:
     - name: Retrieve product download using JBoss Network API
@@ -86,7 +86,7 @@
         client_id: "{{ rhn_username }}"
         client_secret: "{{ rhn_password }}"
         product_type: DISTRIBUTION
-        product_version: "{{ jbcs_version.split('-')[0] }}"
+        product_version: "{{ version.split('-')[0] }}"
         product_category: "core.service.apachehttp"
       register: rhn_products
       delegate_to: localhost
@@ -94,7 +94,7 @@
 
     - name: Determine install zipfile from search results
       ansible.builtin.set_fact:
-        rhn_filtered_products: "{{ rhn_products.results | selectattr('file_path', 'match', '.*/jbcs-httpd24-httpd-' + jbcs_version + '-' + jbcs_distro + '-' + jbcs_arch + '.zip') }}"
+        rhn_filtered_products: "{{ rhn_products.results | selectattr('file_path', 'match', '.*/jbcs-httpd24-httpd-' + version + '-' + distro + '-' + arch + '.zip') }}"
       delegate_to: localhost
       run_once: true
 
@@ -103,21 +103,21 @@
         client_id: "{{ rhn_username }}"
         client_secret: "{{ rhn_password }}"
         product_id: "{{ (rhn_filtered_products | first).id }}"
-        dest: "{{ local_path.stat.path }}/{{ jbcs_bundle }}"
+        dest: "{{ local_path.stat.path }}/{{ bundle }}"
       no_log: "{{ omit_rhn_output | default(true) }}"
       delegate_to: localhost
       run_once: true
 
 - name: Check downloaded archive
   ansible.builtin.stat:
-    path: "{{ local_path.stat.path }}/{{ jbcs_bundle }}"
+    path: "{{ local_path.stat.path }}/{{ bundle }}"
   register: local_archive_path
   delegate_to: localhost
 
 ## copy and unpack
 - name: Copy archive to target nodes
   ansible.builtin.copy:
-    src: "{{ local_path.stat.path }}/{{ jbcs_bundle }}"
+    src: "{{ local_path.stat.path }}/{{ bundle }}"
     dest: "{{ archive }}"
     owner: "{{ httpd.user.name }}"
     group: "{{ httpd.group.name }}"
@@ -159,7 +159,7 @@
   become: true
   ansible.builtin.template:
     src: templates/jbcs-httpd24-httpd.service.j2
-    dest: "/usr/lib/systemd/system/{{ jbcs_service_name }}.service"
+    dest: "/usr/lib/systemd/system/{{ service_name }}.service"
     owner: "{{ httpd.user.name }}"
     group: "{{ httpd.group.name }}"
     mode: 0640

--- a/roles/jbcs/tasks/main.yml
+++ b/roles/jbcs/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: Import firewalld tasks
   ansible.builtin.include_tasks: firewalld.yml
-  when: jbcs_configure_firewalld
+  when: configure_firewalld
 
 - name: Import install tasks
   ansible.builtin.include_tasks: install.yml
@@ -20,14 +20,14 @@
     owner: "{{ httpd.user.name }}"
     group: "{{ httpd.group.name }}"
     mode: 0640
-  when: jbcs_mod_cluster_enable
+  when: mod_cluster_enable
   notify:
     - 'Expire mod_cluster cache and restart'
 
 - name: "Start HTTPd Service"
   become: true
   ansible.builtin.service:
-    name: "{{ jbcs_service_name }}.service"
+    name: "{{ service_name }}.service"
     state: started
     enabled: true
 
@@ -36,8 +36,8 @@
     port: "{{ item }}"
     delay: 2
   loop:
-    - "{{ jbcs_listen_port }}"
-    - "{{ jbcs_ssl_port }}"
-    - "{{ jbcs_mod_cluster_port }}"
+    - "{{ listen_port }}"
+    - "{{ ssl_port }}"
+    - "{{ mod_cluster_port }}"
   when:
-    - jbcs_port_check is defined and jbcs_port_check
+    - port_check is defined and port_check

--- a/roles/jbcs/tasks/mod_cluster_cache_and_restart.yml
+++ b/roles/jbcs/tasks/mod_cluster_cache_and_restart.yml
@@ -10,7 +10,7 @@
 
     - name: Stop JBCS
       ansible.builtin.service:
-        name: "{{ jbcs_service_name }}.service"
+        name: "{{ service_name }}.service"
         state: stopped
 
     - name: Clear modcluster cache
@@ -20,5 +20,5 @@
 
     - name: Start JBCS
       ansible.builtin.service:
-        name: "{{ jbcs_service_name }}.service"
+        name: "{{ service_name }}.service"
         state: started

--- a/roles/jbcs/tasks/ssl.yml
+++ b/roles/jbcs/tasks/ssl.yml
@@ -26,7 +26,7 @@
 
 - name: Disable SSL tasks
   become: true
-  when: not jbcs_ssl_enable
+  when: not ssl_enable
   block:
     - name: "Disabled SSL"
       ansible.builtin.file:
@@ -47,7 +47,7 @@
 
 - name: Enable SSL tasks
   become: true
-  when: jbcs_ssl_enable
+  when: ssl_enable
   block:
     - name: "Ensures HTTPd SSL configuration is deployed"
       ansible.builtin.template:

--- a/roles/jbcs/templates/mod_cluster.conf.j2
+++ b/roles/jbcs/templates/mod_cluster.conf.j2
@@ -20,9 +20,9 @@ SSLProxyCheckPeerName off
 <VirtualHost *:80>
   ProxyPreserveHost On
   ProxyRequests Off
-  ServerName {{ jbcs_external_domain_name }}
+  ServerName {{ external_domain_name }}
   ServerAlias {{ ansible_nodename }}
-  Redirect permanent / https://{{ jbcs_external_domain_name }}/
+  Redirect permanent / https://{{ external_domain_name }}/
 </VirtualHost>
 
 <IfModule manager_module>
@@ -39,7 +39,7 @@ SSLProxyCheckPeerName off
     AdvertiseFrequency 5
     EnableMCPMReceive
 
-    ManagerBalancerName "{{ jbcs_mod_cluster_balancer }}"
+    ManagerBalancerName "{{ mod_cluster_balancer }}"
     CreateBalancers 0
     LogLevel info
     ErrorLog logs/modcluster.log

--- a/roles/jbcs/templates/ssl.conf.j2
+++ b/roles/jbcs/templates/ssl.conf.j2
@@ -5,7 +5,7 @@
 # directives see <URL:http://httpd.apache.org/docs/2.4/mod/mod_ssl.html>
 #
 
-Listen {{ jbcs_ssl_port }}
+Listen {{ ssl_port }}
 
 AddType application/x-x509-ca-cert .crt
 AddType application/x-pkcs7-crl    .crl
@@ -22,7 +22,7 @@ SSLRandomSeed connect builtin
 
 SSLCryptoDevice builtin
 
-<VirtualHost _default_:{{ jbcs_ssl_port }}>
+<VirtualHost _default_:{{ ssl_port }}>
 
 ErrorLog logs/ssl_error_log
 TransferLog logs/ssl_access_log
@@ -35,8 +35,8 @@ SSLCipherSuite HIGH:MEDIUM:!aNULL:!MD5
 #SSLCipherSuite RC4-SHA:AES128-SHA:HIGH:MEDIUM:!aNULL:!MD5
 #SSLHonorCipherOrder on
 
-SSLCertificateFile /etc/pki/tls/certs/{{ jbcs_external_domain_name }}.crt
-SSLCertificateKeyFile /etc/pki/tls/private/{{ jbcs_external_domain_name }}.key
+SSLCertificateFile /etc/pki/tls/certs/{{ external_domain_name }}.crt
+SSLCertificateKeyFile /etc/pki/tls/private/{{ external_domain_name }}.key
 
 <Files ~ \.(cgi|shtml|phtml|php3?)$>
     SSLOptions +StdEnvVars
@@ -49,15 +49,15 @@ BrowserMatch "MSIE [2-5]" nokeepalive ssl-unclean-shutdown downgrade-1.0 force-r
 
 CustomLog logs/ssl_request_log "%t %h %{SSL_PROTOCOL}x %{SSL_CIPHER}x \"%r\" %b"
 
-{% if jbcs_mod_cluster_enable %}
+{% if mod_cluster_enable %}
 <Location /mcm>
     SetHandler mod_cluster-manager
     Require all granted
 </Location>
 {% endif %}
 
-{% if jbcs_proxy_pass | default([]) | length > 0 %}
-{% for proxy in jbcs_proxy_pass %}
+{% if proxy_pass | default([]) | length > 0 %}
+{% for proxy in proxy_pass %}
         HostnameLookups Off
         UseCanonicalName Off
         ProxyPreserveHost On

--- a/roles/jbcs/vars/main.yml
+++ b/roles/jbcs/vars/main.yml
@@ -1,14 +1,14 @@
 ---
 httpd:
-  bind_address: "{{ jbcs_bind_address }}"
-  listen_port: "{{ jbcs_listen_port }}"
+  bind_address: "{{ bind_address }}"
+  listen_port: "{{ listen_port }}"
   mod_cluster:
-    enable: "{{ jbcs_mod_cluster_enable }}"
-    port: "{{ jbcs_mod_cluster_port }}"
-    require: "{{ jbcs_mod_cluster_require }}"
-  home: "{{ jbcs_home }}"
+    enable: "{{ mod_cluster_enable }}"
+    port: "{{ mod_cluster_port }}"
+    require: "{{ mod_cluster_require }}"
+  home: "{{ home }}"
   user:
-    name: "{{ jbcs_user }}"
+    name: "{{ user }}"
   group:
-    name: "{{ jbcs_group }}"
-    id: "{{ jbcs_group_id }}"
+    name: "{{ group }}"
+    id: "{{ group_id }}"


### PR DESCRIPTION
I'm aware this is a considerable change, but I believe the current `jbcs_` is prefix is not ideal because:

* we're within a  `jbcs` role and `jbcs` collection, so having to prefix variables is a bit redundant
* variables are unnecessarily longer
* it seems inconsistent with other collections I've seen (e.g., rhel_system_collections) and even usual modules

Additionally, Contributing says following

> Variables that are internal to the role should be lowercase and start with the role name

but these are not *internal* to the role, if I'm not missing something.

------------------

Especially when you use it like this

```yml
  roles:
    - name: middleware_automation.jbcs.jbcs
      jbcs_bundle: jbcs-httpd24.zip
      jbcs_ssl_enable: false
```

it seems this would be nicer

```yml
  roles:
    - name: middleware_automation.jbcs.jbcs
      bundle: jbcs-httpd24.zip
      ssl_enable: false
```

But if there are users using this already, I understand that the change is problematic.