### PR TITLE
Fix certification requirements for JBCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,15 @@ Using all default values, the collection is invoked from a playbook as follows:
     - jbcs
 ```
 
+
+## Support
+
 <!--start support -->
+
+For bug reports and feature requests, use [GitHub Issues](https://github.com/ansible-middleware/jbcs/issues).
+
 <!--end support -->
+
 
 ## Release and Upgrade Notes
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 antsibull>=0.17.0
 antsibull-docs
 antsibull-changelog
-ansible-core>=2.14.1
+ansible-core>=2.16.0
 ansible-pygments
 sphinx-rtd-theme
 amw-theme>=0.18.1

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -30,6 +30,7 @@ build_ignore:
   - .github
   - .ansible-lint
   - .yamllint
+  - .DS_Store
   - '*.tar.gz'
   - '*.zip'
   - molecule


### PR DESCRIPTION
- Add .DS_Store to build_ignore in galaxy.yml
- Update docs/requirements.txt ansible-core to >=2.16.0 (was 2.14.1)

[AMW-522](https://redhat.atlassian.net/browse/AMW-522)