### PR TITLE
Standardize .gitignore and .ansible-lint configuration

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,6 @@
 # .ansible-lint
+profile: production
+
 exclude_paths:
   - .cache/
   - .github/

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ docs/_build/
 changelogs/.plugin-cache.yaml
 *.pem
 .vscode/
+.ansible

--- a/README.md
+++ b/README.md
@@ -74,5 +74,5 @@ For details on changes between versions, please see the [CHANGELOG](https://gith
 
 Apache License v2.0 or later
 
-See [LICENSE](LICENSE) to view the full text.
+See [LICENSE](https://github.com/ansible-middleware/jbcs/blob/main/LICENSE) to view the full text.
 


### PR DESCRIPTION
- Add .ansible to .gitignore to exclude Ansible runtime artifacts
- Add profile: production to .ansible-lint for production-level linting