### PR TITLE
Remove deprecated ansible-basic-sphinx-ext

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,7 +44,6 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx_antsibull_ext',
-    'ansible_basic_sphinx_ext',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,3 @@
-# ansible_basic_sphinx_ext still imports pkg_resources (removed in setuptools 82+).
-setuptools>=70.0.0,<81.0.0
 antsibull>=0.17.0
 antsibull-docs
 antsibull-changelog
@@ -7,5 +5,4 @@ ansible-core>=2.16.0
 ansible-pygments
 sphinx-rtd-theme
 amw-theme>=0.18.1
-git+https://github.com/felixfontein/ansible-basic-sphinx-ext
 myst-parser


### PR DESCRIPTION
## Summary

- Remove archived/deprecated `ansible-basic-sphinx-ext` from Sphinx extensions and docs requirements
- Remove `setuptools>=70.0.0,<81.0.0` version cap (only needed for the deprecated extension's `pkg_resources` import)
- `sphinx_antsibull_ext` (from `antsibull-docs`) and `ansible-pygments` already provide the same functionality and are already dependencies

## Context

`ansible-basic-sphinx-ext` is [archived and deprecated](https://github.com/felixfontein/ansible-basic-sphinx-ext). Its `assets.py` imports `pkg_resources`, which was removed in setuptools 82+. The current workaround pins `setuptools>=70.0.0,<81.0.0` — a cap that will cause dependency conflicts as the ecosystem moves forward.

The `wildfly` collection has already completed this migration.

## Test plan

- [x] Installed `docs/requirements.txt` in a clean venv with **setuptools 82.0.1** (no cap) — all deps install cleanly
- [x] Ran `sphinx-build` — build succeeded with no errors
- [x] Verified Ansible syntax highlighting works (`AnsibleStyle`, `AnsibleOutputLexer`, `YamlJinjaLexer` all load from `ansible-pygments`)
- [x] Browsed generated docs — theme, navigation, code blocks all render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)